### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -13,6 +13,7 @@
     <extension point="xbmc.addon.metadata">
         <language />
         <platform>all</platform>
+        <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
         <website>http://www.hollywoodreporter.com/</website>
         <source>https://github.com/dersphere/plugin.video.hollywoodreporter</source>
         <forum>http://forum.xbmc.org/showthread.php?tid=139160</forum>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
